### PR TITLE
Checkout code prior to running cloc

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,10 +19,9 @@ jobs:
         node-version: [14.17.5]
 
     steps:
+    - uses: actions/checkout@v3
     - name: Count Lines of Code (cloc)
       uses: djdefi/cloc-action@3
-
-    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
The `cloc` action here seems to be failing as there was no code checked out to scan.